### PR TITLE
Add DropQueue

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,37 @@
+name: Pull request
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "./go.mod"
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+
+  vulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: "./go.mod"
+      - run: go test -race -coverprofile=coverage.out -covermode=atomic
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/push_to_main.yaml
+++ b/.github/workflows/push_to_main.yaml
@@ -1,24 +1,11 @@
-name: CI
+name: Push to main
 
 on:
-  pull_request:
   push:
     branches:    
       - main
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version-file: "./go.mod"
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-
   test:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/craigpastro/pgmq-go.svg)](https://pkg.go.dev/github.com/craigpastro/pgmq-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/craigpastro/pgmq-go)](https://goreportcard.com/report/github.com/craigpastro/pgmq-go)
-[![CI](https://github.com/craigpastro/pgmq-go/actions/workflows/ci.yaml/badge.svg)](https://github.com/craigpastro/pgmq-go/actions/workflows/ci.yaml)
+[![CI](https://github.com/craigpastro/pgmq-go/actions/workflows/push_to_main.yaml/badge.svg)](https://github.com/craigpastro/pgmq-go/actions/workflows/push_to_main.yaml)
 [![codecov](https://codecov.io/github/craigpastro/pgmq-go/branch/main/graph/badge.svg?token=00AJODX77Z)](https://codecov.io/github/craigpastro/pgmq-go)
 
 A Go (Golang) client for
@@ -11,7 +11,7 @@ A Go (Golang) client for
 
 ## Usage
 
-Start a Postgres Instance with the PGMQ extension installed:
+Start a Postgres instance with the PGMQ extension installed:
 
 ```shell
 docker run -d --name postgres -e POSTGRES_PASSWORD=password -p 5432:5432 quay.io/tembo/pgmq-pg:latest

--- a/pgmq.go
+++ b/pgmq.go
@@ -90,6 +90,17 @@ func (p *PGMQ) CreateQueue(ctx context.Context, queue string) error {
 	return nil
 }
 
+// DropQueue deletes the given queue. It deletes the queue's tables, indices,
+// and metadata.
+func (p *PGMQ) DropQueue(ctx context.Context, queue string) error {
+	_, err := p.pool.Exec(ctx, "select pgmq_drop_queue($1)", queue)
+	if err != nil {
+		return wrapPostgresError(err)
+	}
+
+	return nil
+}
+
 // Send sends a single message to a queue. The message id, unique to the
 // queue, is returned.
 func (p *PGMQ) Send(ctx context.Context, queue string, msg map[string]any) (int64, error) {

--- a/pgmq.go
+++ b/pgmq.go
@@ -91,7 +91,7 @@ func (p *PGMQ) CreateQueue(ctx context.Context, queue string) error {
 }
 
 // DropQueue deletes the given queue. It deletes the queue's tables, indices,
-// and metadata.
+// and metadata. It will return an error if the queue does not exist.
 func (p *PGMQ) DropQueue(ctx context.Context, queue string) error {
 	_, err := p.pool.Exec(ctx, "select pgmq_drop_queue($1)", queue)
 	if err != nil {

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -59,6 +59,28 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+func TestDropQueue(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	err = q.DropQueue(ctx, queue)
+	require.NoError(t, err)
+
+	_, err = q.Send(ctx, queue, testMsg1)
+	require.Error(t, err)
+}
+
+func TestDropQueueWhichDoesNotExist(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := q.DropQueue(ctx, queue)
+	require.Error(t, err)
+}
+
 func TestSend(t *testing.T) {
 	ctx := context.Background()
 	queue := t.Name()


### PR DESCRIPTION
Resolves #6.

It seems the latest docker image is still using an older version of pgmq where `drop_queue` also tries to drop `part_config` which does not exist in the non-partitioned case. Will have to wait until it is updated for the tests to pass.