### PR TITLE
Pass ctx to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-    q, err := pgmq.New("postgres://postgres:password@localhost:5432/postgres")
+    q, err := pgmq.New(context.Background(), "postgres://postgres:password@localhost:5432/postgres")
     if err != nil {
         panic(err)
     }

--- a/pgmq.go
+++ b/pgmq.go
@@ -15,7 +15,7 @@ const vtDefault = 30
 
 var (
 	ErrNoRows = errors.New("pgmq: no rows in result set")
-	ErrPing   = errors.New("failed to ping db")
+	ErrPing   = errors.New("pgmq: failed to ping db")
 )
 
 type Message struct {
@@ -40,7 +40,7 @@ type PGMQ struct {
 }
 
 // New establishes a connection to Postgres given by the connString, checks connection, if check is failed,
-// returns ErrPing, that can be retried,then creates the pgmq extension if it does not already exist.
+// returns ErrPing, that can be retried, then creates the pgmq extension if it does not already exist.
 func New(ctx context.Context, connString string) (*PGMQ, error) {
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {

--- a/pgmq.go
+++ b/pgmq.go
@@ -39,8 +39,8 @@ type PGMQ struct {
 	db DB
 }
 
-// New establishes a connection to Postgres given by the connString, then
-// creates the pgmq extension if it does not already exist.
+// New establishes a connection to Postgres given by the connString, checks connection, if check is failed,
+// returns ErrPing, that can be retried,then creates the pgmq extension if it does not already exist.
 func New(ctx context.Context, connString string) (*PGMQ, error) {
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/mock/gomock"
-
 	"github.com/craigpastro/pgmq-go/mocks"
 )
 


### PR DESCRIPTION
New() makes a few remote calls, so I think it would be great to pass context to this function.
Also in my opinion retrying shouldn't be a part of a constructor(at least if don't specify any configs parameters).

So I made a breaking change(is it okay?), added context to New(), remove retrying, added ErrPing error on failed to ping.

Let me know what do you think.