### PR TITLE
BREAKING CHANGES: Add support for transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Go (Golang) client for
 [Postgres Message Queue](https://github.com/tembo-io/pgmq) (PGMQ). Based loosely
 on the [Rust client](https://github.com/tembo-io/pgmq/tree/main/pgmq-rs).
 
-`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument of most functions only needs to satisfy the [DB](https://pkg.go.dev/github.com/craigpastro/pgmq-go#DB) interface, which means it can take, among others, `*pgx.Conn`, `*pgxpool.Pool`, or `pgx.Tx`.
+`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument of most functions only needs to satisfy the [DB](https://pkg.go.dev/github.com/craigpastro/pgmq-go#DB) interface, which means it can take, among others, a `*pgx.Conn`, `*pgxpool.Pool`, or `pgx.Tx`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Go (Golang) client for
 [Postgres Message Queue](https://github.com/tembo-io/pgmq) (PGMQ). Based loosely
 on the [Rust client](https://github.com/tembo-io/pgmq/tree/main/pgmq-rs).
 
-`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument 
+`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument of most functions can take a `pgx.Conn`, `pgx.Pool`, or `pgx.Tx`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Go (Golang) client for
 [Postgres Message Queue](https://github.com/tembo-io/pgmq) (PGMQ). Based loosely
 on the [Rust client](https://github.com/tembo-io/pgmq/tree/main/pgmq-rs).
 
-`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument of most functions can take a `pgx.Conn`, `pgx.Pool`, or `pgx.Tx`.
+`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument of most functions only needs to satisfy the [DB](https://pkg.go.dev/github.com/craigpastro/pgmq-go#DB) interface, which means it can take, among others, `*pgx.Conn`, `*pgxpool.Pool`, or `pgx.Tx`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A Go (Golang) client for
 [Postgres Message Queue](https://github.com/tembo-io/pgmq) (PGMQ). Based loosely
 on the [Rust client](https://github.com/tembo-io/pgmq/tree/main/pgmq-rs).
 
+`pgmq-go` works with [pgx](https://github.com/jackc/pgx). The second argument 
+
 ## Usage
 
 Start a Postgres instance with the PGMQ extension installed:
@@ -32,22 +34,33 @@ import (
 func main() {
     ctx := context.Background()
 
-    q, err := pgmq.New(ctx, "postgres://postgres:password@localhost:5432/postgres")
+    pool, err := pgmq.NewPgxPool(ctx, "postgres://postgres:password@localhost:5432/postgres")
     if err != nil {
         panic(err)
     }
 
-    err = q.CreateQueue(ctx, "my_queue")
+    err = pgmq.CreatePGMQExtension(ctx, pool)
+	if err != nil {
+        panic(err)
+	}
+
+	err := pgmq.CreateQueue(ctx, pool, "my_queue")
     if err != nil {
         panic(err)
     }
 
-    id, err := q.Send(ctx, "my_queue", json.RawMessage(`{"foo": "bar"}`))
+    // We can perform various queue operations using a transaction.
+    tx, err := pool.Begin(ctx)
     if err != nil {
         panic(err)
     }
 
-    msg, err := q.Read(ctx, "my_queue", 30)
+    id, err := pgmq.Send(ctx, tx, "my_queue", json.RawMessage(`{"foo": "bar"}`))
+    if err != nil {
+        panic(err)
+    }
+
+    msg, err := pgmq.Read(ctx, tx, "my_queue", 30)
     if err != nil {
         panic(err)
     }
@@ -55,10 +68,19 @@ func main() {
     // Archive the message by moving it to the "pgmq.a_<queue_name>" table.
     // Alternatively, you can `Delete` the message, or read and delete in one
     // call by using `Pop`.
-    _, err = q.Archive(ctx, "my_queue", id)
+    _, err = pgmq.Archive(ctx, tx, "my_queue", id)
     if err != nil {
         panic(err)
     }
+
+    // Commit the transaction.
+    err = tx.Commit(ctx)
+    if err != nil {
+        panic(err)
+    }
+
+    // Close the connection pool.
+    pool.Close()
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ func main() {
         panic(err)
     }
 
-    err := pgmq.CreateQueue(ctx, pool, "my_queue")
+    err = pgmq.CreateQueue(ctx, pool, "my_queue")
     if err != nil {
         panic(err)
     }

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ func main() {
     }
 
     err = pgmq.CreatePGMQExtension(ctx, pool)
-	if err != nil {
+    if err != nil {
         panic(err)
-	}
+    }
 
-	err := pgmq.CreateQueue(ctx, pool, "my_queue")
+    err := pgmq.CreateQueue(ctx, pool, "my_queue")
     if err != nil {
         panic(err)
     }

--- a/mocks/pgmq.go
+++ b/mocks/pgmq.go
@@ -42,22 +42,10 @@ func (m *MockDB) EXPECT() *MockDBMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
-func (m *MockDB) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockDBMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDB)(nil).Close))
-}
-
 // Exec mocks base method.
-func (m *MockDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+func (m *MockDB) Exec(ctx context.Context, query string, args ...any) (pgconn.CommandTag, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, sql}
+	varargs := []any{ctx, query}
 	for _, a := range args {
 		varargs = append(varargs, a)
 	}
@@ -68,30 +56,16 @@ func (m *MockDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.Comm
 }
 
 // Exec indicates an expected call of Exec.
-func (mr *MockDBMockRecorder) Exec(ctx, sql any, args ...any) *gomock.Call {
+func (mr *MockDBMockRecorder) Exec(ctx, query any, args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, sql}, args...)
+	varargs := append([]any{ctx, query}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockDB)(nil).Exec), varargs...)
 }
 
-// Ping mocks base method.
-func (m *MockDB) Ping(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ping", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Ping indicates an expected call of Ping.
-func (mr *MockDBMockRecorder) Ping(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockDB)(nil).Ping), ctx)
-}
-
 // Query mocks base method.
-func (m *MockDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error) {
+func (m *MockDB) Query(ctx context.Context, query string, args ...any) (pgx.Rows, error) {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, sql}
+	varargs := []any{ctx, query}
 	for _, a := range args {
 		varargs = append(varargs, a)
 	}
@@ -102,16 +76,16 @@ func (m *MockDB) Query(ctx context.Context, sql string, args ...any) (pgx.Rows, 
 }
 
 // Query indicates an expected call of Query.
-func (mr *MockDBMockRecorder) Query(ctx, sql any, args ...any) *gomock.Call {
+func (mr *MockDBMockRecorder) Query(ctx, query any, args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, sql}, args...)
+	varargs := append([]any{ctx, query}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Query", reflect.TypeOf((*MockDB)(nil).Query), varargs...)
 }
 
 // QueryRow mocks base method.
-func (m *MockDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+func (m *MockDB) QueryRow(ctx context.Context, query string, args ...any) pgx.Row {
 	m.ctrl.T.Helper()
-	varargs := []any{ctx, sql}
+	varargs := []any{ctx, query}
 	for _, a := range args {
 		varargs = append(varargs, a)
 	}
@@ -121,8 +95,8 @@ func (m *MockDB) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row 
 }
 
 // QueryRow indicates an expected call of QueryRow.
-func (mr *MockDBMockRecorder) QueryRow(ctx, sql any, args ...any) *gomock.Call {
+func (mr *MockDBMockRecorder) QueryRow(ctx, query any, args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{ctx, sql}, args...)
+	varargs := append([]any{ctx, query}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryRow", reflect.TypeOf((*MockDB)(nil).QueryRow), varargs...)
 }

--- a/pgmq.go
+++ b/pgmq.go
@@ -36,7 +36,7 @@ type DB interface {
 func NewPgxPool(ctx context.Context, connString string) (*pgxpool.Pool, error) {
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error parsing connection string: %w", err)
 	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, cfg)

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -137,6 +137,9 @@ func TestSend(t *testing.T) {
 }
 
 func TestSendAMarshalledStruct(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
 	type A struct {
 		Val int `json:"val"`
 	}
@@ -144,9 +147,6 @@ func TestSendAMarshalledStruct(t *testing.T) {
 	a := A{3}
 	b, err := json.Marshal(a)
 	require.NoError(t, err)
-
-	ctx := context.Background()
-	queue := t.Name()
 
 	err = CreateQueue(ctx, pool, queue)
 	require.NoError(t, err)


### PR DESCRIPTION
Add support to run PGMQ commands using anything that satisfies the DB interface. This means, in particular, that you can run PGMQ commands within a transaction.

Resolves #53.