### PR TITLE
BREAKING CHANGES: Add support for transactions and support for pgmq-pg17 docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: mockgen
 mockgen:
-	mockgen --destination mocks/row.go --package=mocks --build_flags=--mod=mod github.com/jackc/pgx/v5 Row
-	mockgen --source=pgmq.go --destination mocks/pgmq.go --package=mocks
+	go run go.uber.org/mock/mockgen --destination mocks/row.go --package=mocks --build_flags=--mod=mod github.com/jackc/pgx/v5 Row
+	go run go.uber.org/mock/mockgen --source=pgmq.go --destination mocks/pgmq.go --package=mocks
 
 .PHONY: test
 test: mockgen

--- a/go.mod
+++ b/go.mod
@@ -63,11 +63,13 @@ require (
 	go.opentelemetry.io/otel/sdk v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	golang.org/x/tools v0.22.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240318140521-94a12d6c2237 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.18.0 h1:5+9lSbEzPSdWkH32vYPBwEpX8KwDbM52Ud9xBUvNlb0=
+golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -176,6 +178,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.22.0 h1:gqSGLZqv+AI9lIQzniJ0nZDRG5GBPsSi+DRNHWNz6yA=
+golang.org/x/tools v0.22.0/go.mod h1:aCwcsjqvq7Yqt6TNyX7QMU2enbQ/Gt0bo6krSeEri+c=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/mocks/pgmq.go
+++ b/mocks/pgmq.go
@@ -42,18 +42,6 @@ func (m *MockDB) EXPECT() *MockDBMockRecorder {
 	return m.recorder
 }
 
-// Close mocks base method.
-func (m *MockDB) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockDBMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockDB)(nil).Close))
-}
-
 // Exec mocks base method.
 func (m *MockDB) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	m.ctrl.T.Helper()
@@ -72,20 +60,6 @@ func (mr *MockDBMockRecorder) Exec(ctx, sql any, args ...any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]any{ctx, sql}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exec", reflect.TypeOf((*MockDB)(nil).Exec), varargs...)
-}
-
-// Ping mocks base method.
-func (m *MockDB) Ping(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Ping", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Ping indicates an expected call of Ping.
-func (mr *MockDBMockRecorder) Ping(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ping", reflect.TypeOf((*MockDB)(nil).Ping), ctx)
 }
 
 // Query mocks base method.

--- a/pgmq.go
+++ b/pgmq.go
@@ -128,7 +128,7 @@ func (p *PGMQ) Send(ctx context.Context, queue string, msg json.RawMessage) (int
 func (p *PGMQ) SendWithDelay(ctx context.Context, queue string, msg json.RawMessage, delay int) (int64, error) {
 	var msgID int64
 	err := p.db.
-		QueryRow(ctx, "SELECT * FROM pgmq.send($1, $2, $3)", queue, msg, delay).
+		QueryRow(ctx, "SELECT * FROM pgmq.send($1, $2, $3::int)", queue, msg, delay).
 		Scan(&msgID)
 	if err != nil {
 		return 0, wrapPostgresError(err)
@@ -147,7 +147,7 @@ func (p *PGMQ) SendBatch(ctx context.Context, queue string, msgs []json.RawMessa
 // delay is specified in seconds. The message ids, unique to the queue, are
 // returned.
 func (p *PGMQ) SendBatchWithDelay(ctx context.Context, queue string, msgs []json.RawMessage, delay int) ([]int64, error) {
-	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3)", queue, msgs, delay)
+	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3::int)", queue, msgs, delay)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}

--- a/pgmq.go
+++ b/pgmq.go
@@ -161,7 +161,7 @@ func (p *PGMQ) SendBatch(ctx context.Context, queue string, msgs []json.RawMessa
 
 // SendBatchWithDelay sends a batch of messages to a queue with a delay. The
 // delay is specified in seconds. The message ids, unique to the queue, are
-// returned. Only supported in pgmq-pg17 and above.
+// returned.
 func (p *PGMQ) SendBatchWithDelay(ctx context.Context, queue string, msgs []json.RawMessage, delay int) ([]int64, error) {
 	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3::int)", queue, msgs, delay)
 	if err != nil {

--- a/pgmq.go
+++ b/pgmq.go
@@ -28,21 +28,13 @@ type Message struct {
 }
 
 type DB interface {
-	Ping(ctx context.Context) error
 	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
 	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
-	Close()
 }
 
-type PGMQ struct {
-	db DB
-}
-
-// New uses the connString to attempt to establish a connection to Postgres.
-// Once a connetion is established it will create the PGMQ extension if it
-// does not already exist.
-func New(ctx context.Context, connString string) (*PGMQ, error) {
+// NewPgxPool is a convenience function for creating a new *pgxpool.Pool.
+func NewPgxPool(ctx context.Context, connString string) (*pgxpool.Pool, error) {
 	cfg, err := pgxpool.ParseConfig(connString)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing connection string: %w", err)
@@ -53,41 +45,23 @@ func New(ctx context.Context, connString string) (*PGMQ, error) {
 		return nil, fmt.Errorf("error creating pool: %w", err)
 	}
 
-	return NewFromDB(ctx, pool)
+	return pool, nil
 }
 
-// NewFromDB is a bring your own DB version of New. Given an implementation
-// of DB, it will call Ping to ensure the connection has been established,
-// then create the PGMQ extension if it does not already exist.
-func NewFromDB(ctx context.Context, db DB) (*PGMQ, error) {
-	if err := db.Ping(ctx); err != nil {
-		return nil, err
-	}
-
+// CreatePGMQExtension will create the PGMQ extension using the provided DB.
+func CreatePGMQExtension(ctx context.Context, db DB) error {
 	_, err := db.Exec(ctx, "CREATE EXTENSION IF NOT EXISTS pgmq CASCADE")
 	if err != nil {
-		return nil, fmt.Errorf("error creating pgmq extension: %w", err)
+		return fmt.Errorf("error creating pgmq extension: %w", err)
 	}
 
-	return &PGMQ{
-		db: db,
-	}, nil
-}
-
-// Close closes the underlying connection pool.
-func (p *PGMQ) Close() {
-	p.db.Close()
-}
-
-// Ping calls the underlying Ping function of the DB interface.
-func (p *PGMQ) Ping(ctx context.Context) error {
-	return p.db.Ping(ctx)
+	return nil
 }
 
 // CreateQueue creates a new queue. This sets up the queue's tables, indexes,
 // and metadata.
-func (p *PGMQ) CreateQueue(ctx context.Context, queue string) error {
-	_, err := p.db.Exec(ctx, "SELECT pgmq.create($1)", queue)
+func CreateQueue(ctx context.Context, db DB, queue string) error {
+	_, err := db.Exec(ctx, "SELECT pgmq.create($1)", queue)
 	if err != nil {
 		return wrapPostgresError(err)
 	}
@@ -98,8 +72,8 @@ func (p *PGMQ) CreateQueue(ctx context.Context, queue string) error {
 // CreateUnloggedQueue creates a new unlogged queue, which uses an unlogged
 // table under the hood. This sets up the queue's tables, indexes, and
 // metadata.
-func (p *PGMQ) CreateUnloggedQueue(ctx context.Context, queue string) error {
-	_, err := p.db.Exec(ctx, "SELECT pgmq.create_unlogged($1)", queue)
+func CreateUnloggedQueue(ctx context.Context, db DB, queue string) error {
+	_, err := db.Exec(ctx, "SELECT pgmq.create_unlogged($1)", queue)
 	if err != nil {
 		return wrapPostgresError(err)
 	}
@@ -109,8 +83,8 @@ func (p *PGMQ) CreateUnloggedQueue(ctx context.Context, queue string) error {
 
 // DropQueue deletes the given queue. It deletes the queue's tables, indices,
 // and metadata. It will return an error if the queue does not exist.
-func (p *PGMQ) DropQueue(ctx context.Context, queue string) error {
-	_, err := p.db.Exec(ctx, "SELECT pgmq.drop_queue($1)", queue)
+func DropQueue(ctx context.Context, db DB, queue string) error {
+	_, err := db.Exec(ctx, "SELECT pgmq.drop_queue($1)", queue)
 	if err != nil {
 		return wrapPostgresError(err)
 	}
@@ -120,15 +94,15 @@ func (p *PGMQ) DropQueue(ctx context.Context, queue string) error {
 
 // Send sends a single message to a queue. The message id, unique to the
 // queue, is returned.
-func (p *PGMQ) Send(ctx context.Context, queue string, msg json.RawMessage) (int64, error) {
-	return p.SendWithDelay(ctx, queue, msg, 0)
+func Send(ctx context.Context, db DB, queue string, msg json.RawMessage) (int64, error) {
+	return SendWithDelay(ctx, db, queue, msg, 0)
 }
 
 // SendWithDelay sends a single message to a queue with a delay. The delay
 // is specified in seconds. The message id, unique to the queue, is returned.
-func (p *PGMQ) SendWithDelay(ctx context.Context, queue string, msg json.RawMessage, delay int) (int64, error) {
+func SendWithDelay(ctx context.Context, db DB, queue string, msg json.RawMessage, delay int) (int64, error) {
 	var msgID int64
-	err := p.db.
+	err := db.
 		QueryRow(ctx, "SELECT * FROM pgmq.send($1, $2, $3::int)", queue, msg, delay).
 		Scan(&msgID)
 	if err != nil {
@@ -141,9 +115,9 @@ func (p *PGMQ) SendWithDelay(ctx context.Context, queue string, msg json.RawMess
 // SendWithDelayTimestamp sends a single message to a queue with a delay. The
 // delay is specified as a timestamp. The message id, unique to the queue, is
 // returned. Only supported in pgmq-pg17 and above.
-func (p *PGMQ) SendWithDelayTimestamp(ctx context.Context, queue string, msg json.RawMessage, delay time.Time) (int64, error) {
+func SendWithDelayTimestamp(ctx context.Context, db DB, queue string, msg json.RawMessage, delay time.Time) (int64, error) {
 	var msgID int64
-	err := p.db.
+	err := db.
 		QueryRow(ctx, "SELECT * FROM pgmq.send($1, $2, $3::timestamptz)", queue, msg, delay).
 		Scan(&msgID)
 	if err != nil {
@@ -155,15 +129,15 @@ func (p *PGMQ) SendWithDelayTimestamp(ctx context.Context, queue string, msg jso
 
 // SendBatch sends a batch of messages to a queue. The message ids, unique to
 // the queue, are returned.
-func (p *PGMQ) SendBatch(ctx context.Context, queue string, msgs []json.RawMessage) ([]int64, error) {
-	return p.SendBatchWithDelay(ctx, queue, msgs, 0)
+func SendBatch(ctx context.Context, db DB, queue string, msgs []json.RawMessage) ([]int64, error) {
+	return SendBatchWithDelay(ctx, db, queue, msgs, 0)
 }
 
 // SendBatchWithDelay sends a batch of messages to a queue with a delay. The
 // delay is specified in seconds. The message ids, unique to the queue, are
 // returned.
-func (p *PGMQ) SendBatchWithDelay(ctx context.Context, queue string, msgs []json.RawMessage, delay int) ([]int64, error) {
-	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3::int)", queue, msgs, delay)
+func SendBatchWithDelay(ctx context.Context, db DB, queue string, msgs []json.RawMessage, delay int) ([]int64, error) {
+	rows, err := db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3::int)", queue, msgs, delay)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}
@@ -185,8 +159,8 @@ func (p *PGMQ) SendBatchWithDelay(ctx context.Context, queue string, msgs []json
 // SendBatchWithDelayTimestamp sends a batch of messages to a queue with a
 // delay. The delay is specified as a timestamp. The message ids, unique to
 // the queue, are returned.
-func (p *PGMQ) SendBatchWithDelayTimestamp(ctx context.Context, queue string, msgs []json.RawMessage, delay time.Time) ([]int64, error) {
-	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3::timestamptz)", queue, msgs, delay)
+func SendBatchWithDelayTimestamp(ctx context.Context, db DB, queue string, msgs []json.RawMessage, delay time.Time) ([]int64, error) {
+	rows, err := db.Query(ctx, "SELECT * FROM pgmq.send_batch($1, $2::jsonb[], $3::timestamptz)", queue, msgs, delay)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}
@@ -209,13 +183,13 @@ func (p *PGMQ) SendBatchWithDelayTimestamp(ctx context.Context, queue string, ms
 // messages are invisible, an ErrNoRows errors is returned. If a message is
 // returned, it is made invisible for the duration of the visibility timeout
 // (vt) in seconds.
-func (p *PGMQ) Read(ctx context.Context, queue string, vt int64) (*Message, error) {
+func Read(ctx context.Context, db DB, queue string, vt int64) (*Message, error) {
 	if vt == 0 {
 		vt = vtDefault
 	}
 
 	var msg Message
-	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.read($1, $2, $3)", queue, vt, 1)
+	rows, err := db.Query(ctx, "SELECT * FROM pgmq.read($1, $2, $3)", queue, vt, 1)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}
@@ -243,12 +217,12 @@ func (p *PGMQ) Read(ctx context.Context, queue string, vt int64) (*Message, erro
 // messages that are returned are made invisible for the duration of the
 // visibility timeout (vt) in seconds. If vt is 0 it will be set to the
 // default value, vtDefault.
-func (p *PGMQ) ReadBatch(ctx context.Context, queue string, vt int64, numMsgs int64) ([]*Message, error) {
+func ReadBatch(ctx context.Context, db DB, queue string, vt int64, numMsgs int64) ([]*Message, error) {
 	if vt == 0 {
 		vt = vtDefault
 	}
 
-	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.read($1, $2, $3)", queue, vt, numMsgs)
+	rows, err := db.Query(ctx, "SELECT * FROM pgmq.read($1, $2, $3)", queue, vt, numMsgs)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}
@@ -278,9 +252,9 @@ func (p *PGMQ) ReadBatch(ctx context.Context, queue string, vt int64, numMsgs in
 // Similar to Read and ReadBatch if no messages are available an ErrNoRows is
 // returned. Unlike these methods, the visibility timeout does not apply.
 // This is because the message is immediately deleted.
-func (p *PGMQ) Pop(ctx context.Context, queue string) (*Message, error) {
+func Pop(ctx context.Context, db DB, queue string) (*Message, error) {
 	var msg Message
-	rows, err := p.db.Query(ctx, "SELECT * FROM pgmq.pop($1)", queue)
+	rows, err := db.Query(ctx, "SELECT * FROM pgmq.pop($1)", queue)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}
@@ -308,9 +282,9 @@ func (p *PGMQ) Pop(ctx context.Context, queue string) (*Message, error) {
 // id. View messages on the archive table with sql:
 //
 //	SELECT * FROM pgmq.a_<queue_name>;
-func (p *PGMQ) Archive(ctx context.Context, queue string, msgID int64) (bool, error) {
+func Archive(ctx context.Context, db DB, queue string, msgID int64) (bool, error) {
 	var archived bool
-	err := p.db.QueryRow(ctx, "SELECT pgmq.archive($1, $2::bigint)", queue, msgID).Scan(&archived)
+	err := db.QueryRow(ctx, "SELECT pgmq.archive($1, $2::bigint)", queue, msgID).Scan(&archived)
 	if err != nil {
 		return false, wrapPostgresError(err)
 	}
@@ -322,8 +296,8 @@ func (p *PGMQ) Archive(ctx context.Context, queue string, msgID int64) (bool, er
 // table by their ids. View messages on the archive table with sql:
 //
 //	SELECT * FROM pgmq.a_<queue_name>;
-func (p *PGMQ) ArchiveBatch(ctx context.Context, queue string, msgIDs []int64) ([]int64, error) {
-	rows, err := p.db.Query(ctx, "SELECT pgmq.archive($1, $2::bigint[])", queue, msgIDs)
+func ArchiveBatch(ctx context.Context, db DB, queue string, msgIDs []int64) ([]int64, error) {
+	rows, err := db.Query(ctx, "SELECT pgmq.archive($1, $2::bigint[])", queue, msgIDs)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}
@@ -344,9 +318,9 @@ func (p *PGMQ) ArchiveBatch(ctx context.Context, queue string, msgIDs []int64) (
 // Delete deletes a message from the queue by its id. This is a permanent
 // delete and cannot be undone. If you want to retain a log of the message,
 // use the Archive method.
-func (p *PGMQ) Delete(ctx context.Context, queue string, msgID int64) (bool, error) {
+func Delete(ctx context.Context, db DB, queue string, msgID int64) (bool, error) {
 	var deleted bool
-	err := p.db.QueryRow(ctx, "SELECT pgmq.delete($1, $2::bigint)", queue, msgID).Scan(&deleted)
+	err := db.QueryRow(ctx, "SELECT pgmq.delete($1, $2::bigint)", queue, msgID).Scan(&deleted)
 	if err != nil {
 		return false, wrapPostgresError(err)
 	}
@@ -357,8 +331,8 @@ func (p *PGMQ) Delete(ctx context.Context, queue string, msgID int64) (bool, err
 // DeleteBatch deletes a batch of messages from the queue by their ids. This
 // is a permanent delete and cannot be undone. If you want to retain a log of
 // the messages, use the ArchiveBatch method.
-func (p *PGMQ) DeleteBatch(ctx context.Context, queue string, msgIDs []int64) ([]int64, error) {
-	rows, err := p.db.Query(ctx, "SELECT pgmq.delete($1, $2::bigint[])", queue, msgIDs)
+func DeleteBatch(ctx context.Context, db DB, queue string, msgIDs []int64) ([]int64, error) {
+	rows, err := db.Query(ctx, "SELECT pgmq.delete($1, $2::bigint[])", queue, msgIDs)
 	if err != nil {
 		return nil, wrapPostgresError(err)
 	}

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -70,7 +70,7 @@ func TestSendTimestamp(t *testing.T) {
 
 func TestSendAMarshalledStruct(t *testing.T) {
 	pg16.TestSendAMarshalledStruct(t)
-	//pg17.TestSendAMarshalledStruct(t)
+	pg17.TestSendAMarshalledStruct(t)
 }
 
 func TestSendInvalidJSONFails(t *testing.T) {
@@ -90,7 +90,7 @@ func TestSendBatchWithDelayTimestamp(t *testing.T) {
 
 func TestRead(t *testing.T) {
 	pg16.TestRead(t)
-	//pg17.TestRead(t)
+	pg17.TestRead(t)
 }
 
 func TestReadEmptyQueueReturnsNoRows(t *testing.T) {
@@ -100,12 +100,12 @@ func TestReadEmptyQueueReturnsNoRows(t *testing.T) {
 
 func TestReadBatch(t *testing.T) {
 	pg16.TestReadBatch(t)
-	//pg17.TestReadBatch(t)
+	pg17.TestReadBatch(t)
 }
 
 func TestPop(t *testing.T) {
 	pg16.TestPop(t)
-	//pg17.TestPop(t)
+	pg17.TestPop(t)
 }
 
 func TestPopEmptyQueueReturnsNoRows(t *testing.T) {

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -4,374 +4,119 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"testing"
-	"time"
 
-	"github.com/avast/retry-go/v4"
 	"github.com/craigpastro/pgmq-go/mocks"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"go.uber.org/mock/gomock"
 )
 
-var q *PGMQ
-
 var (
+	pg16 = Database{
+		image: "quay.io/tembo/pgmq-pg:latest",
+	}
+	pg17 = Database{
+		image: "tembo.docker.scarf.sh/tembo/pg17-pgmq:latest",
+	}
 	testMsg1 = json.RawMessage(`{"foo": "bar1"}`)
-	testMsg2 = json.RawMessage(`{"foo": "bar2"}`)
+	testMsg2 = json.RawMessage(`{"foo": "bar1"}`)
 )
 
+func (d *Database) Close() {
+	d.q.Close()
+	_ = d.container.Terminate(context.Background())
+}
+
 func TestMain(m *testing.M) {
-	ctx := context.Background()
-
-	req := testcontainers.ContainerRequest{
-		Image:        "quay.io/tembo/pgmq-pg:latest",
-		ExposedPorts: []string{"5432/tcp"},
-		Env:          map[string]string{"POSTGRES_USER": "postgres", "POSTGRES_PASSWORD": "password"},
-		WaitingFor:   wait.ForLog("database system is ready to accept connections"),
-	}
-
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		panic(err)
-	}
-
-	host, err := container.Host(ctx)
-	if err != nil {
-		panic(err)
-	}
-
-	port, err := container.MappedPort(ctx, "5432/tcp")
-	if err != nil {
-		panic(err)
-	}
-
-	connString := fmt.Sprintf("postgres://postgres:password@%s:%s/postgres", host, port.Port())
-
-	q, err = retry.DoWithData(func() (*PGMQ, error) {
-		return New(ctx, connString)
-	})
-	if err != nil {
-		panic(err)
-	}
-
+	pg16.Init()
+	pg17.Init()
 	code := m.Run()
-
-	q.Close()
-	_ = container.Terminate(context.Background())
-
+	pg16.Close()
+	pg17.Close()
 	os.Exit(code)
 }
 
 func TestPing(t *testing.T) {
-	err := q.Ping(context.Background())
-	require.NoError(t, err)
+	pg16.TestPing(t)
+	pg17.TestPing(t)
 }
 
 func TestCreateAndDropQueue(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	err = q.DropQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Send(ctx, queue, testMsg1)
-	require.Error(t, err)
+	pg16.TestCreateAndDropQueue(t)
+	pg17.TestCreateAndDropQueue(t)
 }
 
 func TestDropQueueWhichDoesNotExist(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.DropQueue(ctx, queue)
-	require.Error(t, err)
+	pg16.TestDropQueueWhichDoesNotExist(t)
+	pg17.TestDropQueueWhichDoesNotExist(t)
 }
 
 func TestCreateUnloggedAndDropQueue(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateUnloggedQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Send(ctx, queue, testMsg1)
-	require.NoError(t, err)
-
-	err = q.DropQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Send(ctx, queue, testMsg1)
-	require.Error(t, err)
+	pg16.TestCreateUnloggedAndDropQueue(t)
+	pg17.TestCreateUnloggedAndDropQueue(t)
 }
 
 func TestSend(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	id, err := q.Send(ctx, queue, testMsg1)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, id)
-
-	id, err = q.Send(ctx, queue, testMsg2)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, id)
+	pg16.TestSend(t)
+	pg17.TestSend(t)
 }
 
 func TestSendAMarshalledStruct(t *testing.T) {
-	type A struct {
-		Val int `json:"val"`
-	}
-
-	a := A{3}
-	b, err := json.Marshal(a)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	queue := t.Name()
-
-	err = q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Send(ctx, queue, b)
-	require.NoError(t, err)
-
-	msg, err := q.Read(ctx, queue, 0)
-	require.NoError(t, err)
-
-	var aa A
-	err = json.Unmarshal(msg.Message, &aa)
-	require.NoError(t, err)
-
-	require.EqualValues(t, a, aa)
+	pg16.TestSendAMarshalledStruct(t)
 }
 
 func TestSendInvalidJSONFails(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Send(ctx, queue, json.RawMessage(`{"foo":}`))
-	require.Error(t, err)
+	pg16.TestSendInvalidJSONFails(t)
 }
 
 func TestSendBatch(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	ids, err := q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
-	require.NoError(t, err)
-	require.Equal(t, []int64{1, 2}, ids)
+	pg16.TestSendBatch(t)
 }
 
 func TestRead(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	id, err := q.Send(ctx, queue, testMsg1)
-	require.NoError(t, err)
-
-	msg, err := q.Read(ctx, queue, 0)
-	require.NoError(t, err)
-	require.Equal(t, testMsg1, msg.Message)
-	require.Equal(t, id, msg.MsgID)
-
-	// Visibility timeout will still be in effect.
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestRead(t)
 }
 
 func TestReadEmptyQueueReturnsNoRows(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestReadEmptyQueueReturnsNoRows(t)
 }
 
 func TestReadBatch(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
-	require.NoError(t, err)
-
-	time.Sleep(time.Second)
-	msgs, err := q.ReadBatch(ctx, queue, 0, 5)
-	require.NoError(t, err)
-	require.Len(t, msgs, 2)
-
-	require.Equal(t, testMsg1, msgs[0].Message)
-	require.Equal(t, testMsg2, msgs[1].Message)
-
-	// Visibility timeout will still be in effect.
-	msgs, err = q.ReadBatch(ctx, queue, 0, 5)
-	require.NoError(t, err)
-	require.Empty(t, msgs)
+	pg16.TestReadBatch(t)
 }
 
 func TestPop(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	id, err := q.Send(ctx, queue, testMsg1)
-	require.NoError(t, err)
-
-	msg, err := q.Pop(ctx, queue)
-	require.NoError(t, err)
-	require.Equal(t, testMsg1, msg.Message)
-	require.Equal(t, id, msg.MsgID)
-
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestPop(t)
 }
 
 func TestPopEmptyQueueReturnsNoRows(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	_, err = q.Pop(ctx, queue)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestPopEmptyQueueReturnsNoRows(t)
 }
 
 func TestArchive(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	id, err := q.Send(ctx, queue, testMsg1)
-	require.NoError(t, err)
-
-	archived, err := q.Archive(ctx, queue, id)
-	require.NoError(t, err)
-	require.True(t, archived)
-
-	// Let's just check that something landed in the archive table.
-	stmt := fmt.Sprintf("SELECT * FROM pgmq.a_%s", queue)
-	tag, err := q.db.Exec(ctx, stmt)
-	require.NoError(t, err)
-	require.EqualValues(t, 1, tag.RowsAffected())
-
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestArchive(t)
 }
 
 func TestArchiveNotExist(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	archived, err := q.Archive(ctx, queue, 100)
-	require.NoError(t, err)
-	require.False(t, archived)
+	pg16.TestArchiveNotExist(t)
 }
 
 func TestArchiveBatch(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	ids, err := q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
-	require.NoError(t, err)
-
-	archived, err := q.ArchiveBatch(ctx, queue, ids)
-	require.NoError(t, err)
-	require.Equal(t, ids, archived)
-
-	// Let's check that the two messages landed in the archive table.
-	stmt := fmt.Sprintf("SELECT * FROM pgmq.a_%s", queue)
-	tag, err := q.db.Exec(ctx, stmt)
-	require.NoError(t, err)
-	require.EqualValues(t, 2, tag.RowsAffected())
-
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestArchiveBatch(t)
 }
 
 func TestDelete(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	id, err := q.Send(ctx, queue, testMsg1)
-	require.NoError(t, err)
-
-	deleted, err := q.Delete(ctx, queue, id)
-	require.NoError(t, err)
-	require.True(t, deleted)
-
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestDelete(t)
 }
 
 func TestDeleteNotExist(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	deleted, err := q.Delete(ctx, queue, 100)
-	require.NoError(t, err)
-	require.False(t, deleted)
+	pg16.TestDeleteNotExist(t)
 }
 
 func TestDeleteBatch(t *testing.T) {
-	ctx := context.Background()
-	queue := t.Name()
-
-	err := q.CreateQueue(ctx, queue)
-	require.NoError(t, err)
-
-	ids, err := q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
-	require.NoError(t, err)
-
-	deleted, err := q.DeleteBatch(ctx, queue, ids)
-	require.NoError(t, err)
-	require.EqualValues(t, ids, deleted)
-
-	_, err = q.Read(ctx, queue, 0)
-	require.ErrorIs(t, err, ErrNoRows)
+	pg16.TestDeleteBatch(t)
 }
 
 func TestErrorCases(t *testing.T) {

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -63,6 +63,11 @@ func TestSend(t *testing.T) {
 	pg17.TestSend(t)
 }
 
+func TestSendTimestamp(t *testing.T) {
+	//pg16.TestSendWithDelayTimestamp(t) delay with timestamp is not supported in pg16
+	pg17.TestSendWithDelayTimestamp(t)
+}
+
 func TestSendAMarshalledStruct(t *testing.T) {
 	pg16.TestSendAMarshalledStruct(t)
 	//pg17.TestSendAMarshalledStruct(t)
@@ -76,6 +81,11 @@ func TestSendInvalidJSONFails(t *testing.T) {
 func TestSendBatch(t *testing.T) {
 	pg16.TestSendBatch(t)
 	pg17.TestSendBatch(t)
+}
+
+func TestSendBatchWithDelayTimestamp(t *testing.T) {
+	//pg16.TestSendBatchWithDelayTimestamp(t) delay with timestamp is not supported in pg16
+	pg17.TestSendBatchWithDelayTimestamp(t)
 }
 
 func TestRead(t *testing.T) {

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -65,58 +65,72 @@ func TestSend(t *testing.T) {
 
 func TestSendAMarshalledStruct(t *testing.T) {
 	pg16.TestSendAMarshalledStruct(t)
+	//pg17.TestSendAMarshalledStruct(t)
 }
 
 func TestSendInvalidJSONFails(t *testing.T) {
 	pg16.TestSendInvalidJSONFails(t)
+	pg17.TestSendInvalidJSONFails(t)
 }
 
 func TestSendBatch(t *testing.T) {
 	pg16.TestSendBatch(t)
+	pg17.TestSendBatch(t)
 }
 
 func TestRead(t *testing.T) {
 	pg16.TestRead(t)
+	//pg17.TestRead(t)
 }
 
 func TestReadEmptyQueueReturnsNoRows(t *testing.T) {
 	pg16.TestReadEmptyQueueReturnsNoRows(t)
+	pg17.TestReadEmptyQueueReturnsNoRows(t)
 }
 
 func TestReadBatch(t *testing.T) {
 	pg16.TestReadBatch(t)
+	//pg17.TestReadBatch(t)
 }
 
 func TestPop(t *testing.T) {
 	pg16.TestPop(t)
+	//pg17.TestPop(t)
 }
 
 func TestPopEmptyQueueReturnsNoRows(t *testing.T) {
 	pg16.TestPopEmptyQueueReturnsNoRows(t)
+	pg17.TestPopEmptyQueueReturnsNoRows(t)
 }
 
 func TestArchive(t *testing.T) {
 	pg16.TestArchive(t)
+	pg17.TestArchive(t)
 }
 
 func TestArchiveNotExist(t *testing.T) {
 	pg16.TestArchiveNotExist(t)
+	pg17.TestArchiveNotExist(t)
 }
 
 func TestArchiveBatch(t *testing.T) {
 	pg16.TestArchiveBatch(t)
+	pg17.TestArchiveBatch(t)
 }
 
 func TestDelete(t *testing.T) {
 	pg16.TestDelete(t)
+	pg17.TestDelete(t)
 }
 
 func TestDeleteNotExist(t *testing.T) {
 	pg16.TestDeleteNotExist(t)
+	pg17.TestDeleteNotExist(t)
 }
 
 func TestDeleteBatch(t *testing.T) {
 	pg16.TestDeleteBatch(t)
+	pg17.TestDeleteBatch(t)
 }
 
 func TestErrorCases(t *testing.T) {

--- a/pgmq_test_struct.go
+++ b/pgmq_test_struct.go
@@ -68,6 +68,18 @@ func (d *Database) TestSend(t *testing.T) {
 	require.EqualValues(t, 2, id)
 }
 
+func (d *Database) TestSendWithDelayTimestamp(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	id, err := d.q.SendWithDelayTimestamp(ctx, queue, testMsg1, time.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.EqualValues(t, 1, id)
+}
+
 func (d *Database) TestPing(t *testing.T) {
 	err := d.q.Ping(context.Background())
 	require.NoError(t, err)
@@ -150,6 +162,18 @@ func (d *Database) TestSendBatch(t *testing.T) {
 	require.NoError(t, err)
 
 	ids, err := d.q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2}, ids)
+}
+
+func (d *Database) TestSendBatchWithDelayTimestamp(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	ids, err := d.q.SendBatchWithDelayTimestamp(ctx, queue, []json.RawMessage{testMsg1, testMsg2}, time.Now().Add(time.Second))
 	require.NoError(t, err)
 	require.Equal(t, []int64{1, 2}, ids)
 }

--- a/pgmq_test_struct.go
+++ b/pgmq_test_struct.go
@@ -1,0 +1,348 @@
+package pgmq
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v4"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type Database struct {
+	q         *PGMQ
+	image     string
+	container testcontainers.Container
+}
+
+func (d *Database) Init() {
+	ctx := context.Background()
+	req := testcontainers.ContainerRequest{
+		Image:        d.image,
+		ExposedPorts: []string{"5432/tcp"},
+		Env:          map[string]string{"POSTGRES_USER": "postgres", "POSTGRES_PASSWORD": "password"},
+		WaitingFor:   wait.ForLog("database system is ready to accept connections"),
+	}
+	var err error
+	d.container, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		panic(err)
+	}
+	host, err := d.container.Host(ctx)
+	if err != nil {
+		panic(err)
+	}
+	port, err := d.container.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		panic(err)
+	}
+	connString := fmt.Sprintf("postgres://postgres:password@%s:%s/postgres", host, port.Port())
+	d.q, err = retry.DoWithData(func() (*PGMQ, error) {
+		return New(ctx, connString)
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (d *Database) TestSend(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	id, err := d.q.Send(ctx, queue, testMsg1)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, id)
+
+	id, err = d.q.Send(ctx, queue, testMsg2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, id)
+}
+
+func (d *Database) TestPing(t *testing.T) {
+	err := d.q.Ping(context.Background())
+	require.NoError(t, err)
+}
+
+func (d *Database) TestCreateAndDropQueue(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	err = d.q.DropQueue(ctx, queue)
+	require.NoError(t, err)
+}
+
+func (d *Database) TestDropQueueWhichDoesNotExist(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.DropQueue(ctx, queue)
+	require.Error(t, err)
+}
+
+func (d *Database) TestCreateUnloggedAndDropQueue(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateUnloggedQueue(ctx, queue)
+	require.NoError(t, err)
+
+	err = d.q.DropQueue(ctx, queue)
+	require.NoError(t, err)
+}
+
+func (d *Database) TestSendAMarshalledStruct(t *testing.T) {
+	type A struct {
+		Val int `json:"val"`
+	}
+
+	a := A{3}
+	b, err := json.Marshal(a)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	queue := t.Name()
+
+	err = d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	_, err = d.q.Send(ctx, queue, b)
+	require.NoError(t, err)
+
+	msg, err := d.q.Read(ctx, queue, 0)
+	require.NoError(t, err)
+
+	var aa A
+	err = json.Unmarshal(msg.Message, &aa)
+	require.NoError(t, err)
+
+	require.EqualValues(t, a, aa)
+}
+
+func (d *Database) TestSendInvalidJSONFails(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	_, err = d.q.Send(ctx, queue, json.RawMessage(`{"foo":}`))
+	require.Error(t, err)
+}
+
+func (d *Database) TestSendBatch(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	ids, err := d.q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2}, ids)
+}
+
+func (d *Database) TestRead(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	id, err := d.q.Send(ctx, queue, testMsg1)
+	require.NoError(t, err)
+
+	msg, err := d.q.Read(ctx, queue, 0)
+	require.NoError(t, err)
+	require.Equal(t, testMsg1, msg.Message)
+	require.Equal(t, id, msg.MsgID)
+
+	// Visibility timeout will still be in effect.
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestReadEmptyQueueReturnsNoRows(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestReadBatch(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	_, err = d.q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
+	require.NoError(t, err)
+
+	time.Sleep(time.Second)
+	msgs, err := d.q.ReadBatch(ctx, queue, 0, 5)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	require.Equal(t, testMsg1, msgs[0].Message)
+	require.Equal(t, testMsg2, msgs[1].Message)
+
+	// Visibility timeout will still be in effect.
+	msgs, err = d.q.ReadBatch(ctx, queue, 0, 5)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+}
+
+func (d *Database) TestPop(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	id, err := d.q.Send(ctx, queue, testMsg1)
+	require.NoError(t, err)
+
+	msg, err := d.q.Pop(ctx, queue)
+	require.NoError(t, err)
+	require.Equal(t, testMsg1, msg.Message)
+	require.Equal(t, id, msg.MsgID)
+
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestPopEmptyQueueReturnsNoRows(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	_, err = d.q.Pop(ctx, queue)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestArchive(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	id, err := d.q.Send(ctx, queue, testMsg1)
+	require.NoError(t, err)
+
+	archived, err := d.q.Archive(ctx, queue, id)
+	require.NoError(t, err)
+	require.True(t, archived)
+
+	// Let's just check that something landed in the archive table.
+	stmt := fmt.Sprintf("SELECT * FROM pgmq.a_%s", queue)
+	tag, err := d.q.db.Exec(ctx, stmt)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, tag.RowsAffected())
+
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestArchiveNotExist(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	archived, err := d.q.Archive(ctx, queue, 100)
+	require.NoError(t, err)
+	require.False(t, archived)
+}
+
+func (d *Database) TestArchiveBatch(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	ids, err := d.q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
+	require.NoError(t, err)
+
+	archived, err := d.q.ArchiveBatch(ctx, queue, ids)
+	require.NoError(t, err)
+	require.Equal(t, ids, archived)
+
+	// Let's check that the two messages landed in the archive table.
+	stmt := fmt.Sprintf("SELECT * FROM pgmq.a_%s", queue)
+	tag, err := d.q.db.Exec(ctx, stmt)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, tag.RowsAffected())
+
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestDelete(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	id, err := d.q.Send(ctx, queue, testMsg1)
+	require.NoError(t, err)
+
+	deleted, err := d.q.Delete(ctx, queue, id)
+	require.NoError(t, err)
+	require.True(t, deleted)
+
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}
+
+func (d *Database) TestDeleteNotExist(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	deleted, err := d.q.Delete(ctx, queue, 100)
+	require.NoError(t, err)
+	require.False(t, deleted)
+}
+
+func (d *Database) TestDeleteBatch(t *testing.T) {
+	ctx := context.Background()
+	queue := t.Name()
+
+	err := d.q.CreateQueue(ctx, queue)
+	require.NoError(t, err)
+
+	ids, err := d.q.SendBatch(ctx, queue, []json.RawMessage{testMsg1, testMsg2})
+	require.NoError(t, err)
+
+	deleted, err := d.q.DeleteBatch(ctx, queue, ids)
+	require.NoError(t, err)
+	require.EqualValues(t, ids, deleted)
+
+	_, err = d.q.Read(ctx, queue, 0)
+	require.ErrorIs(t, err, ErrNoRows)
+}


### PR DESCRIPTION
# Added support for pg17-pgmq
Fixed issue #66 by adding ::int to third argument of send.
Added support for the new sql functions send and send batch with delay using timestamp as delay and not int.
`SendWithDelayTimestamp` `SendBatchWithDelayTimestamp`

### Test struct
Created test object to be able to run tests against the two docker images:
`quay.io/tembo/pgmq-pg:latest`
`tembo.docker.scarf.sh/tembo/pg17-pgmq:latest`  🆕

### Handle headers response
Also had to add header field to the response message to handle new `headers::jsonb` field in the read, read batch and pop sql functions. These functions on the golang side now checks the length of the response before scanning into message struct as pgmq-pg17 returns 6 fields instead of 5. (I checked the Python package and it still only has 5 fields and the pgmq documentation does not mention the headers either 🤷 https://tembo.io/pgmq/api/sql/functions/#read).

Mock tests had to be updated to expect Query and not QueryRow for read and pop methods.

This is currently the read function in the sql code `pg17-pgmq:latest`:
```  pgSQL

DECLARE
    sql TEXT;
    qtable TEXT := pgmq.format_table_name(queue_name, 'q');
BEGIN
    sql := FORMAT(
        $QUERY$
        WITH cte AS
        (
            SELECT msg_id
            FROM pgmq.%I
            WHERE vt <= clock_timestamp() AND CASE
                WHEN %L != '{}'::jsonb THEN (message @> %2$L)::integer
                ELSE 1
            END = 1
            ORDER BY msg_id ASC
            LIMIT $1
            FOR UPDATE SKIP LOCKED
        )
        UPDATE pgmq.%I m
        SET
            vt = clock_timestamp() + %L,
            read_ct = read_ct + 1
        FROM cte
        WHERE m.msg_id = cte.msg_id
        RETURNING m.msg_id, m.read_ct, m.enqueued_at, m.vt, m.message, m.headers;
        $QUERY$,
        qtable, conditional, qtable, make_interval(secs => vt)
    );
    RETURN QUERY EXECUTE sql USING qty;
END;

```

