### PR TITLE
Fix for drop queue

### DIFF
--- a/pgmq.go
+++ b/pgmq.go
@@ -84,9 +84,13 @@ func CreateUnloggedQueue(ctx context.Context, db DB, queue string) error {
 // DropQueue deletes the given queue. It deletes the queue's tables, indices,
 // and metadata. It will return an error if the queue does not exist.
 func DropQueue(ctx context.Context, db DB, queue string) error {
-	_, err := db.Exec(ctx, "SELECT pgmq.drop_queue($1)", queue)
+	var exists bool
+	err := db.QueryRow(ctx, "SELECT pgmq.drop_queue($1)", queue).Scan(&exists)
 	if err != nil {
 		return wrapPostgresError(err)
+	}
+	if !exists {
+		return fmt.Errorf("queue %s does not exist", queue)
 	}
 
 	return nil

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -22,8 +22,6 @@ var (
 	}
 )
 
-
-
 func TestMain(m *testing.M) {
 	pg16.Init()
 	pg17.Init()

--- a/pgmq_test.go
+++ b/pgmq_test.go
@@ -22,10 +22,7 @@ var (
 	}
 )
 
-func (d *Database) Close() {
-	d.Pool.Close()
-	_ = d.container.Terminate(context.Background())
-}
+
 
 func TestMain(m *testing.M) {
 	pg16.Init()
@@ -168,7 +165,8 @@ func TestErrorCases(t *testing.T) {
 	})
 
 	t.Run("dropQueueError", func(t *testing.T) {
-		mockDB.EXPECT().Exec(ctx, "SELECT pgmq.drop_queue($1)", queue).Return(cmdTag, testErr)
+		mockDB.EXPECT().QueryRow(ctx, "SELECT pgmq.drop_queue($1)", queue).Return(mockRow)
+		mockRow.EXPECT().Scan(gomock.Any()).Return(testErr)
 		err := DropQueue(ctx, mockDB, queue)
 		require.ErrorContains(t, err, "postgres error")
 	})

--- a/pgmq_test_struct.go
+++ b/pgmq_test_struct.go
@@ -68,6 +68,11 @@ func (d *Database) Init() {
 	}
 }
 
+func (d *Database) Close() {
+	d.Pool.Close()
+	_ = d.container.Terminate(context.Background())
+}
+
 func (d *Database) TestSend(t *testing.T) {
 	ctx := context.Background()
 	queue := t.Name()


### PR DESCRIPTION
The semantics of pgmq between pg16 and pg17 seem to be different. In pg16 it returns an error, but in pg17 it simple returns a false row. This PR handles both of these cases in `DropQueue`.